### PR TITLE
Remove unnecessary header marker

### DIFF
--- a/charts/postgresql/_initialize_instance.md.erb
+++ b/charts/postgresql/_initialize_instance.md.erb
@@ -14,4 +14,4 @@ Alternatively, you can specify custom scripts using the initdbScripts parameter 
 
 In addition to these options, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the postgresql.initdbScriptsCM parameter. Note that this will override the two previous options. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the initdbScriptsSecret parameter.
 
-The allowed extensions are *.sh*, *.sql* and *.sql.gz*.<%
+The allowed extensions are *.sh*, *.sql* and *.sql.gz*.


### PR DESCRIPTION
<% is not necessary at this position, probably a copy-paste error.