### PR TITLE
Fix: Fixed a minor indentation issue in sidecars and init containers documentation page

### DIFF
--- a/common/_configure_sidecar_init_containers.md.erb
+++ b/common/_configure_sidecar_init_containers.md.erb
@@ -18,7 +18,7 @@ sidecars:
   imagePullPolicy: Always
   ports:
   - name: portname
-   containerPort: 1234
+    containerPort: 1234
 ~~~
 
 If these sidecars export extra ports, extra port definitions can be added using the *\*.service.extraPorts* parameter (where available), as shown in the example below:


### PR DESCRIPTION
Hi, I was going through [this](https://docs.bitnami.com/kubernetes/infrastructure/redis-cluster/configuration/configure-sidecar-init-containers/) for some internal work. I found out this minor YAML indentation issue. I am making this PR which fixes this indentation and aligns `containerPort: 1234` properly under the 0th port entry.

Thanks for this awesome ready-made charts.