### PR TITLE
Move Harbor Upgrading Notes to chart-docs

### DIFF
--- a/charts/harbor/_upgrade.md.erb
+++ b/charts/harbor/_upgrade.md.erb
@@ -1,0 +1,124 @@
+<%
+=begin
+apps: harbor
+platforms: kubernetes
+id: upgrade
+title: Upgrading Notes
+category: administration
+weight: 20
+highlight: 20
+=end %>
+
+### To 12.0.0
+
+This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository. Additionally updates the PostgreSQL & Redis subcharts to their newest major 11.x.x and 16.x.x, respectively, which contain similar changes.
+
+#### What changes were introduced in this major version?
+
+* *harborAdminPassword* was renamed to *adminPassword* and *forcePassword* is deprecated.
+* Traffic exposure was completely redesign:
+  * There's a new *exposureType* parameter has been added that allows deciding whether to expose Harbor using Ingress or a NGINX proxy.
+  * *service.type* doesn't acccept "Ingress" as a valid value anymore. To configure traffic exposure through Ingress set *exposureType* to "ingress".
+  * *service.tls* map has been renamed to *nginx.tls*. To configure TLS termination with Ingress, set *ingress.tls* parameter.
+* *xxxImage* parameters (e.g. "nginxImage") have been renamed to *xxx.image* (e.g. "nginx.image").
+* *xxx.replicas* parameters (e.g. "nginx.replicas") have been renamed to *xxx.replicaCount* (e.g. "nginx.replicaCount").
+* *persistence.persistentVolumeClaim.xxx.accessMode* parameters (e.g. "persistence.persistentVolumeClaim.registry.accessMode") have been renamed to *persistence.persistentVolumeClaim.xxx.accessModes* (e.g. "persistence.persistentVolumeClaim.registry.accessModes") and expect an array instead of a string.
+* *caBundleSecretName* was renamed to *internalTLS.caBundleSecret*.
+* *persistence.imageChartStorage.caBundleSecretName* was renamed to *persistence.imageChartStorage.caBundleSecret*.
+* *core.uaaSecretName* was renamed to *core.uaaSecret*.
+* *ingress* map is completely redefined.
+
+#### Upgrading Instructions
+
+To upgrade to *12.0.0* from *11.x*, it should be done reusing the PVC(s) used to hold the data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is *harbor* and the release namespace *default*):
+
+> NOTE: Please, create a backup of your database before running any of those actions.
+
+1. Obtain the credentials and the names of the PVCs used to hold the data on your current release:
+
+        export HARBOR_PASSWORD=$(kubectl get secret --namespace default harbor-core-envvars -o jsonpath="{.data.HARBOR_ADMIN_PASSWORD}" | base64 --decode)
+        export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace default harbor-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+        export POSTGRESQL_PVC=$(kubectl get pvc -l app.kubernetes.io/instance=harbor,app.kubernetes.io/name=postgresql,role=primary -o jsonpath="{.items[0].metadata.name}")
+
+2. Delete the PostgreSQL statefulset (notice the option *--cascade=false*) and secret:
+
+        kubectl delete statefulsets.apps --cascade=false harbor-postgresql
+        kubectl delete secret harbor-postgresql --namespace default
+
+3. Upgrade your release using the same PostgreSQL version:
+
+        CURRENT_PG_VERSION=$(kubectl exec harbor-postgresql-0 -- bash -c 'echo $BITNAMI_IMAGE_VERSION')
+        helm upgrade harbor bitnami/harbor \
+          --set adminPassword=$HARBOR_PASSWORD \
+          --set postgresql.image.tag=$CURRENT_PG_VERSION \
+          --set postgresql.auth.password=$POSTGRESQL_PASSWORD \
+          --set postgresql.persistence.existingClaim=$POSTGRESQL_PVC
+
+4. Delete the existing PostgreSQL pods and the new statefulset will create a new one:
+
+        kubectl delete pod harbor-postgresql-0
+
+### To 11.0.0
+
+This major update the Redis&trade; subchart to its newest major, 15.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1500) you can find more info about the specific changes.
+
+### To 10.0.0
+
+This major updates the Redis&trade; subchart to it newest major, 14.0.0, which contains breaking changes. For more information on this subchart's major and the steps needed to migrate your data from your previous release, please refer to [Redis&trade; upgrade notes.](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1400).
+
+### To 9.7.0
+
+This new version of the chart bumps the version of Harbor to [`2.2.0`](https://github.com/goharbor/harbor/releases/tag/v2.2.0) which deprecates built-in Clair. If you still want to use Clair, you will need to set `clair.enabled` to `true` and Clair scanner and the Harbor adapter will be deployed. Follow [these steps](https://goharbor.io/docs/latest/administration/vulnerability-scanning/pluggable-scanners) to add it as an additional interrogation service for Harbor.
+
+Please note that Clair might be fully deprecated from this chart in following updates.
+
+### To 9.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+#### What changes were introduced in this major version?
+
+* Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+* Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+* After running *helm dependency update*, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+* The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Chart.
+* This chart depends on the **PostgreSQL 10** instead of **PostgreSQL 9**. Apart from the same changes that are described in this section, there are also other major changes due to the master/slave nomenclature was replaced by primary/readReplica. [Here](https://github.com/bitnami/charts/pull/4385) you can find more information about the changes introduced.
+
+#### Considerations when upgrading to this version
+
+* If you want to upgrade to this version using Helm v2, this scenario is not supported as this version does not support Helm v2 anymore.
+* If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3.
+
+#### Useful links
+
+* [Bitnami Tutorial](https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues)
+* [Helm docs](https://helm.sh/docs/topics/v2_v3_migration)
+* [Helm Blog](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3)
+
+#### Upgrading Instructions
+
+To upgrade to *9.0.0* from *8.x*, it should be done reusing the PVC(s) used to hold the data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is *harbor* and the release namespace *default*):
+
+> NOTE: Please, create a backup of your database before running any of those actions.
+
+1. Obtain the credentials and the names of the PVCs used to hold the data on your current release:
+
+        export HARBOR_PASSWORD=$(kubectl get secret --namespace default harbor-core-envvars -o jsonpath="{.data.HARBOR_ADMIN_PASSWORD}" | base64 --decode)
+        export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace default harbor-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+        export POSTGRESQL_PVC=$(kubectl get pvc -l app.kubernetes.io/instance=harbor,app.kubernetes.io/name=postgresql,role=master -o jsonpath="{.items[0].metadata.name}")
+
+2. Delete the PostgreSQL statefulset (notice the option *--cascade=false*)
+
+        kubectl delete statefulsets.apps --cascade=false harbor-postgresql
+
+3. Upgrade your release:
+
+        helm upgrade harbor bitnami/harbor \
+          --set harborAdminPassword=$HARBOR_PASSWORD \
+          --set postgresql.image.tag=$CURRENT_PG_VERSION \
+          --set postgresql.postgresqlPassword$POSTGRESQL_PASSWORD \
+          --set postgresql.persistence.existingClaim=$POSTGRESQL_PVC
+
+4. Delete the existing PostgreSQL pods and the new statefulset will create a new one:
+
+        kubectl delete pod harbor-postgresql-0


### PR DESCRIPTION
This PR moves the Harbor "Upgrading Notes" to https://docs.bitnami.com

Follow-up https://github.com/bitnami/charts/pull/9263, reducing the README.md size.