### PR TITLE
[bitnami/keycloak] Remove unused 'database-password' key

### DIFF
--- a/charts/keycloak/_manage_passwords.md.erb
+++ b/charts/keycloak/_manage_passwords.md.erb
@@ -38,7 +38,6 @@ To use a single existing secret, use the *existingSecret* parameter, as shown be
       keyMapping:
         admin-password: myPasswordKey
         management-password: myManagementPasswordKey
-        database-password: myDatabasePasswordKey
         tls-keystore-password: myTlsKeystorePasswordKey
         tls-truststore-password: myTlsTruststorePasswordKey
 


### PR DESCRIPTION
Remove unused 'database-password' key commented example
in values.yaml.

Closes https://github.com/bitnami/charts/issues/9274.

Signed-off-by: Brad Solomon <81818815+brsolomon-deloitte@users.noreply.github.com>