### PR TITLE
[bitnami/*] Update Redis dependent charts upgrading notes

### DIFF
--- a/charts/apache-airflow/_upgrade.md.erb
+++ b/charts/apache-airflow/_upgrade.md.erb
@@ -9,6 +9,10 @@ weight: 20
 highlight: 20
 =end %>
 
+### To 13.0.0
+
+This major update the Redis&trade; subchart to its newest major, 17.0.0, which updates Redis&trade; from its version 6.2 to the latest 7.0.
+
 ### To 12.0.0
 
 This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository. Additionally updates the PostgreSQL & Redis subcharts to their newest major 11.x.x and 16.x.x, respectively, which contain similar changes.

--- a/charts/argo-cd/_upgrade.md.erb
+++ b/charts/argo-cd/_upgrade.md.erb
@@ -1,0 +1,57 @@
+<%
+=begin
+apps: argo-cd
+platforms: kubernetes, tanzu-application-catalog
+id: upgrade
+title: Upgrading Notes
+category: administration
+weight: 20
+highlight: 20
+=end %>
+
+### To 4.0.0
+
+This major update the Redis&trade; subchart to its newest major, 17.0.0, which updates Redis&trade; from its version 6.2 to the latest 7.0.
+
+### To 3.0.0
+
+This major update the Redis&reg; subchart to its newest major, 16.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1600) you can find more info about the specific changes.
+
+Additionally, this chart has been standardised adding features from other charts.
+
+### To 2.0.0
+
+This major update the Redis&reg; subchart to its newest major, 15.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1500) you can find more info about the specific changes.
+
+### To 1.0.0
+
+In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for every component
+
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/argo-cd
+  tag: 2.0.5
+```
+VS
+```yaml
+controller:
+  image:
+    registry: docker.io
+    repository: bitnami/argo-cd
+    tag: 2.0.5
+...
+server:
+  image:
+    registry: docker.io
+    repository: bitnami/argo-cd
+    tag: 2.0.5
+...
+repoServer:
+  image:
+    registry: docker.io
+    repository: bitnami/argo-cd
+    tag: 2.0.5
+```
+
+See [PR#7113](https://github.com/bitnami/charts/pull/7113) for more info about the implemented changes

--- a/charts/discourse/_upgrade.md.erb
+++ b/charts/discourse/_upgrade.md.erb
@@ -9,6 +9,10 @@ weight: 20
 highlight: 20
 =end %>
 
+### To 8.0.0
+
+This major update the Redis&trade; subchart to its newest major, 17.0.0, which updates Redis&trade; from its version 6.2 to the latest 7.0.
+
 ### To 7.0.0
 
 This major upgrades the Discourse version to *2.8.0*.

--- a/charts/harbor/_upgrade.md.erb
+++ b/charts/harbor/_upgrade.md.erb
@@ -9,6 +9,10 @@ weight: 20
 highlight: 20
 =end %>
 
+### To 15.0.0
+
+This major update the Redis&trade; subchart to its newest major, 17.0.0, which updates Redis&trade; from its version 6.2 to the latest 7.0.
+
 ### To 12.x.x
 
 This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository. Additionally updates the PostgreSQL & Redis subcharts to their newest major 11.x.x and 16.x.x, respectively, which contain similar changes.


### PR DESCRIPTION
**Description of change**

Updates the upgrading notes for Airflow, Discourse and Harbor.

Moves existing upgrading notes for ArgoCD from its README.md to charts-docs.

Related to bitnami/charts#11170, bitnami/charts#11171, bitnami/charts#11172, bitnami/charts#11173