### PR TITLE
[oauth2-proxy] Add install and Upgrading notes

### DIFF
--- a/charts/oauth2-proxy/_upgrade.md.erb
+++ b/charts/oauth2-proxy/_upgrade.md.erb
@@ -1,0 +1,24 @@
+<%
+=begin
+apps: oauth2-proxy
+platforms: kubernetes
+id: upgrade
+title: Upgrading Notes
+category: administration
+weight: 20
+highlight: 20
+=end %>
+
+### To 3.0.0
+
+This major update the Redis&reg; subchart to its newest major, 17.0.0, which updates Redis&reg; from its version 6.2 to version 7.0.
+
+### To 2.0.0
+
+This major update the Redis&reg; subchart to its newest major, 16.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1600) you can find more info about the specific changes.
+
+Additionally, this chart has been standardised adding features from other charts.
+
+### To 1.0.0
+
+This major update the Redis&reg; subchart to its newest major, 15.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1500) you can find more info about the specific changes.

--- a/charts/oauth2-proxy/install.md.erb
+++ b/charts/oauth2-proxy/install.md.erb
@@ -1,0 +1,1 @@
+        $ helm install MY-RELEASE <%= variable :repository_name, :platform %>/oauth2-proxy


### PR DESCRIPTION
This PR adds `oauth2-proxy` to the charts folder and moves its Upgrading notes from its README.md