### PR TITLE
[bitnami/*] Replace bitnami-docker-* URLs by the equivalent bitnami/containers ones

### DIFF
--- a/DESIGN_DECISIONS.md
+++ b/DESIGN_DECISIONS.md
@@ -20,12 +20,12 @@ Checking our support cases, we found that users found extremely difficult to deb
 
 ## 2021-02-25: Replace `bitnami/minideb` by `bitnami/bitnami-shell`
 
-**TL;DR:** [`bitnami/minideb`](https://github.com/bitnami/minideb) is not used on auxiliar containers (such as init containers or sidecar containers) anymore. [`bitnami/bitnami-shell`](https://github.com/bitnami/bitnami-docker-bitnami-shell) will be used from now on, instead.
+**TL;DR:** [`bitnami/minideb`](https://github.com/bitnami/minideb) is not used on auxiliar containers (such as init containers or sidecar containers) anymore. [`bitnami/bitnami-shell`](https://github.com/bitnami/containers/tree/main/bitnami/bitnami-shell) will be used from now on, instead.
 
 The [`bitnami/minideb`](https://github.com/bitnami/minideb) image started being a good fit for auxiliar containers (see [why use minideb](https://github.com/bitnami/minideb#why-use-minideb) section).
 However, several of these containers required non trivial packages to be present (e.g. `sysctl`). We can argue that many of these requirements would be a good-to-have. Nevertheless, we aim to keep [`bitnami/minideb`](https://github.com/bitnami/minideb) very light-weight and, more important, with a very small vulnerability surface.
 
-Hence, instead of adding this good-to-have delta to [`bitnami/minideb`](https://github.com/bitnami/minideb), we have developed [`bitnami/bitnami-shell`](https://github.com/bitnami/bitnami-docker-bitnami-shell). This allows us to keep `minideb` small and focused, which is a good quality to build other images on top, while our charts can use an enriched container with useful system packages or useful shell scripts.
+Hence, instead of adding this good-to-have delta to [`bitnami/minideb`](https://github.com/bitnami/minideb), we have developed [`bitnami/bitnami-shell`](https://github.com/bitnami/containers/tree/main/bitnami/bitnami-shell). This allows us to keep `minideb` small and focused, which is a good quality to build other images on top, while our charts can use an enriched container with useful system packages or useful shell scripts.
 
 ## 2021-01-20: Removal of _values-production.yaml_ files
 

--- a/charts/aspnet-core/_deploy_custom_app.md.erb
+++ b/charts/aspnet-core/_deploy_custom_app.md.erb
@@ -32,8 +32,8 @@ Find more information about the process to create your own image in the [Develop
 
 This is done using two different init containers:
 
-* *clone-repository*: uses the [<%= variable :catalog_name, :platform %> Git image](https://github.com/bitnami/bitnami-docker-git) to download the repository.
-* *dotnet-publish*: uses the [<%= variable :catalog_name, :platform %> .Net SDK image](https://github.com/bitnami/bitnami-docker-dotnet-sdk) to build/publish the ASP.NET Core application.
+* *clone-repository*: uses the [<%= variable :catalog_name, :platform %> Git image](https://github.com/bitnami/containers/tree/main/bitnami/git) to download the repository.
+* *dotnet-publish*: uses the [<%= variable :catalog_name, :platform %> .Net SDK image](https://github.com/bitnami/containers/tree/main/bitnami/dotnet-sdk) to build/publish the ASP.NET Core application.
 
   To use this feature, set the *appFromExternalRepo.enabled* to *true* and set the repository and branch to use setting the *appFromExternalRepo.clone.repository* and *appFromExternalRepo.clone.revision* parameters. Then, specify the subfolder under the Git repository containing the ASP.NET Core application setting the *appFromExternalRepo.publish.subFolder* parameter. Finally, provide the start command to use setting the *appFromExternalRepo.startCommand*.
 

--- a/charts/cassandra/_customize_new_instance.md.erb
+++ b/charts/cassandra/_customize_new_instance.md.erb
@@ -9,7 +9,7 @@ weight: 40
 highlight: 40
 =end %>
 
-The [<%= variable :catalog_name, :platform %> Apache Cassandra image](https://github.com/bitnami/bitnami-docker-cassandra) image supports the use of custom scripts to initialize a fresh instance. This may be done by creating a Kubernetes ConfigMap that includes the necessary *sh* or *cql* scripts and passing this ConfigMap to the chart via the *initDBConfigMap* parameter.
+The [<%= variable :catalog_name, :platform %> Apache Cassandra image](https://github.com/bitnami/containers/tree/main/bitnami/cassandra) image supports the use of custom scripts to initialize a fresh instance. This may be done by creating a Kubernetes ConfigMap that includes the necessary *sh* or *cql* scripts and passing this ConfigMap to the chart via the *initDBConfigMap* parameter.
 
 The scripts are mounted in the */docker-entrypoint.initdb* directory.
 

--- a/charts/discourse/_upgrade.md.erb
+++ b/charts/discourse/_upgrade.md.erb
@@ -93,7 +93,7 @@ This major update the Redis&trade; subchart to its newest major, 15.0.0. For mor
 
 #### What changes were introduced in this major version?
 
-The [Bitnami Discourse](https://github.com/bitnami/bitnami-docker-discourse) image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-discourse/tree/master/2/debian-10/rootfs) folder of the container image repository.
+The [Bitnami Discourse](https://github.com/bitnami/containers/tree/main/bitnami/discourse) image was refactored and now the source code is published in GitHub in the `rootfs` folder of the container image repository.
 
 #### Upgrading Instructions
 

--- a/charts/influxdb/_initialize_instance.md.erb
+++ b/charts/influxdb/_initialize_instance.md.erb
@@ -8,7 +8,7 @@ category: administration
 weight: 20
 =end %>
 
-The [<%= variable :catalog_name, :platform %> InfluxDB](https://github.com/bitnami/bitnami-docker-influxdb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder files/docker-entrypoint-initdb.d so they can be consumed as a ConfigMap.
+The [<%= variable :catalog_name, :platform %> InfluxDB](https://github.com/bitnami/containers/tree/main/bitnami/influxdb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder files/docker-entrypoint-initdb.d so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the influxdb.initdbScripts parameter.
 

--- a/charts/mariadb-galera/_initialize_instance.md.erb
+++ b/charts/mariadb-galera/_initialize_instance.md.erb
@@ -8,7 +8,7 @@ category: administration
 weight: 20
 =end %>
 
-The [<%= variable :catalog_name, :platform %> MariaDB Galera](https://github.com/bitnami/bitnami-docker-mariadb-galera) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder *files/docker-entrypoint-initdb.d* so they can be consumed as a ConfigMap.
+The [<%= variable :catalog_name, :platform %> MariaDB Galera](https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder *files/docker-entrypoint-initdb.d* so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the initdbScripts parameter as dict.
 

--- a/charts/mariadb/_customize_new_instance.md.erb
+++ b/charts/mariadb/_customize_new_instance.md.erb
@@ -9,7 +9,7 @@ weight: 20
 highlight: 20
 =end %>
 
-The [<%= variable :catalog_name, :platform %> MariaDB](https://github.com/bitnami/bitnami-docker-mariadb) image supports the use of custom scripts to initialize a fresh instance.
+The [<%= variable :catalog_name, :platform %> MariaDB](https://github.com/bitnami/containers/tree/main/bitnami/mariadb) image supports the use of custom scripts to initialize a fresh instance.
 
 Custom scripts may be specified using the *initdbScripts* parameter. Alternatively, an external ConfigMap may be created with all the initialization scripts and the ConfigMap passed to the chart via the *initdbScriptsConfigMap* parameter. Note that this will override the *initdbScripts* parameter.
 

--- a/charts/minio/_customize_deployment.md.erb
+++ b/charts/minio/_customize_deployment.md.erb
@@ -9,7 +9,7 @@ weight: 10
 highlight: 10
 =end %>
 
-You can add extra environment variables (this is useful for advanced operations like custom init scripts), by using the *extraEnv* property as shown below where [MINIO_HTTP_TRACE](https://github.com/bitnami/bitnami-docker-minio#http-log-trace) is the variable defined for setting debug logging.
+You can add extra environment variables (this is useful for advanced operations like custom init scripts), by using the *extraEnv* property as shown below where [MINIO_HTTP_TRACE](https://github.com/bitnami/containers/tree/main/bitnami/minio#http-log-trace) is the variable defined for setting debug logging.
 
     extraEnv:
       - name: MINIO_HTTP_TRACE

--- a/charts/mongodb-sharded/_initialize_instance.md.erb
+++ b/charts/mongodb-sharded/_initialize_instance.md.erb
@@ -8,6 +8,6 @@ category: administration
 weight: 20
 =end %>
 
-The [<%= variable :catalog_name, :platform %> MongoDB image](https://github.com/bitnami/bitnami-docker-mongodb-sharded) allows you to use your custom scripts to initialize a fresh instance. You can create a custom config map and give it via initScriptsCM.
+The [<%= variable :catalog_name, :platform %> MongoDB image](https://github.com/bitnami/containers/tree/main/bitnami/mongodb-sharded) allows you to use your custom scripts to initialize a fresh instance. You can create a custom config map and give it via initScriptsCM.
 
 The allowed extensions are *.sh*, and *.js*.

--- a/charts/mysql/_customize_new_instance.md.erb
+++ b/charts/mysql/_customize_new_instance.md.erb
@@ -9,7 +9,7 @@ weight: 20
 highlight: 20
 =end %>
 
-The [<%= variable :catalog_name, :platform %> MySQL](https://github.com/bitnami/bitnami-docker-mysql) image supports the use of custom scripts to initialize a fresh instance.
+The [<%= variable :catalog_name, :platform %> MySQL](https://github.com/bitnami/containers/tree/main/bitnami/mysql) image supports the use of custom scripts to initialize a fresh instance.
 
 In order to execute the scripts, they must be located inside the chart folder *files/docker-entrypoint-initdb.d* so that they may be consumed as a Kubernetes ConfigMap. The allowed extensions are:
 

--- a/charts/odoo/_upgrade.md.erb
+++ b/charts/odoo/_upgrade.md.erb
@@ -43,7 +43,7 @@ To upgrade to *21.0.0* from *20.x*, it should be done reusing the PVC(s) used to
 
 ### 19.0.0
 
-The [Bitnami Odoo](https://github.com/bitnami/bitnami-docker-odoo) image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-odoo/tree/master/14/debian-10/rootfs) folder of the container image repository.
+The [Bitnami Odoo](https://github.com/bitnami/containers/tree/main/bitnami/odoo) image was refactored and now the source code is published in GitHub in the `rootfs` folder of the container image repository.
 
 #### Upgrading Instructions
 

--- a/charts/parse/_deploy_cloud_functions.md.erb
+++ b/charts/parse/_deploy_cloud_functions.md.erb
@@ -8,7 +8,7 @@ category: configuration
 weight: 50
 =end %>
 
-The [<%= variable :catalog_name, :platform %> Parse image](https://github.com/bitnami/bitnami-docker-parse) allows you to deploy your Cloud functions with Parse Cloud Code (a feature which allows running a piece of code in your Parse Server instead of the user's mobile devices). In order to add your custom scripts, they must be located inside the chart folder *files/cloud* so they can be consumed as a ConfigMap.
+The [<%= variable :catalog_name, :platform %> Parse image](https://github.com/bitnami/containers/tree/main/bitnami/parse) allows you to deploy your Cloud functions with Parse Cloud Code (a feature which allows running a piece of code in your Parse Server instead of the user's mobile devices). In order to add your custom scripts, they must be located inside the chart folder *files/cloud* so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the cloudCodeScripts parameter as dict.
 

--- a/charts/postgresql-ha/_initialize_instance.md.erb
+++ b/charts/postgresql-ha/_initialize_instance.md.erb
@@ -8,7 +8,7 @@ category: administration
 weight: 20
 =end %>
 
-The [<%= variable :catalog_name, :platform %> PostgreSQL with Repmgr](https://github.com/bitnami/bitnami-docker-postgresql-repmgr) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder *files/docker-entrypoint-initdb.d* so they can be consumed as a ConfigMap.
+The [<%= variable :catalog_name, :platform %> PostgreSQL with Repmgr](https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder *files/docker-entrypoint-initdb.d* so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the initdbScripts parameter as dict.
 

--- a/charts/postgresql/_initialize_instance.md.erb
+++ b/charts/postgresql/_initialize_instance.md.erb
@@ -8,7 +8,7 @@ category: administration
 weight: 20
 =end %>
 
-The [<%= variable :catalog_name, :platform %> PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder *files/docker-entrypoint-initdb.d* so they can be consumed as a ConfigMap.
+The [<%= variable :catalog_name, :platform %> PostgreSQL](https://github.com/bitnami/containers/tree/main/bitnami/postgresql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder *files/docker-entrypoint-initdb.d* so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the initdbScripts parameter as dict.
 

--- a/charts/redmine/_upgrade.md.erb
+++ b/charts/redmine/_upgrade.md.erb
@@ -76,7 +76,7 @@ See [PR#7114](https://github.com/bitnami/charts/pull/7114) for more info about t
 
 ### To 16.0.0
 
-The [Bitnami Redmine](https://github.com/bitnami/bitnami-docker-redmine) image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-redmine/tree/master/14/debian-10/rootfs) folder of the container image repository.
+The [Bitnami Redmine](https://github.com/bitnami/containers/tree/main/bitnami/redmine) image was refactored and now the source code is published in GitHub in the `rootfs` folder of the container image repository.
 
 #### Upgrading Instructions
 

--- a/charts/wordpress/_use_external_database.md.erb
+++ b/charts/wordpress/_use_external_database.md.erb
@@ -13,4 +13,4 @@ highlight: 20
 
 If the database already contains data from a previous WordPress installation, set the *wordpressSkipInstall* parameter to *true*. This parameter forces the container to skip the WordPress installation wizard. Otherwise, the container will assume it is a fresh installation and execute the installation wizard, potentially modifying or resetting the data in the existing database.
 
-[Refer to the container documentation for more information](https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database).
+[Refer to the container documentation for more information](https://github.com/bitnami/containers/tree/main/bitnami/wordpress#connect-wordpress-docker-container-to-an-existing-database).

--- a/common/troubleshoot_helm_chart_issues.md.erb
+++ b/common/troubleshoot_helm_chart_issues.md.erb
@@ -178,8 +178,8 @@ The example below analyzes a common issue faced by Bitnami users in this context
         $ kubectl logs MY-RELEASE-mongodb-58f6f48f87-vvc7m
         mongodb 08:56:27.10
         mongodb 08:56:27.11 Welcome to the Bitnami mongodb container
-        mongodb 08:56:27.11 Subscribe to project updates by watching https://github.com/bitnami/bitnami-docker-mongodb
-        mongodb 08:56:27.12 Submit issues and feature requests at https://github.com/bitnami/bitnami-docker-mongodb/issues
+        mongodb 08:56:27.12 Subscribe to project updates by watching https://github.com/bitnami/containers
+        mongodb 08:56:27.12 Submit issues and feature requests at https://github.com/bitnami/containers/issues
         mongodb 08:56:27.12
         mongodb 08:56:27.12 INFO  ==> ** Starting MongoDB setup **
         mongodb 08:56:27.14 INFO  ==> Validating settings in MONGODB_* env vars...


### PR DESCRIPTION
### Description of the change

Since we are migrating the different `bitnami/bitnami-docker-foo` repositories to a single `bitnami/containers` repository, the aim of this PR is to replace the different URLs reflecting the new source.

### Benefits

Links are updated pointing to the new source.

### Possible drawbacks

Since changes were done in a batch way maybe some links can be broken, in order to avoid this, I used the [`markdown-link-check` tool](https://www.npmjs.com/package/markdown-link-check) to check the markdown ones