### PR TITLE
[bitnami/minio] Modify distributed mode documentation for Minio

### DIFF
--- a/charts/minio/_configure_server_distributed_mode.md.erb
+++ b/charts/minio/_configure_server_distributed_mode.md.erb
@@ -23,6 +23,6 @@ You can also bootstrap MinIO(R) server in distributed mode in several zones, and
     statefulset.zones=2
     statefulset.drivesPerNode=2
 
-> NOTE: The total number of drives should be multiple of 4 to guarantee erasure coding. Please set a combination of nodes, and drives per node that match this condition.
+> NOTE: The total number of drives should be greater than 4 to guarantee erasure coding. Please set a combination of nodes, and drives per node that match this condition.
 
 


### PR DESCRIPTION
Signed-off-by: Cori Avila <amisericordi@vmware.com>

### Description of the change
The way to validate the value of totalDrives for Minio, checking if the value was a multiple of 4, was not correct according to the [documentation](https://docs.min.io/minio/baremetal/concepts/erasure-coding.html) provided on the official page and as reported by the user in this [ticket](https://github.com/bitnami/charts/issues/11202).
The change has been made in this [PR](https://github.com/bitnami/charts/pull/11678).