### PR TITLE
Fixing broken link and removing deprecated section

### DIFF
--- a/charts/etcd/_backup_restore.md.erb
+++ b/charts/etcd/_backup_restore.md.erb
@@ -39,4 +39,4 @@ This method involves the following steps:
 * Use Velero to restore the backed-up PVs on the destination cluster.
 * Create a new etcd deployment on the destination cluster with the same deployment name, credentials and other parameters as the original. This new deployment will use the restored PVs and hence the original data.
 
-Refer to our detailed [tutorial on backing up and restoring etcd chart deployments on Kubernetes](https://docs.bitnami.com/tutorials/backup-restore-data-etcd-kubernetes/), which covers both these approaches, for more information.
+Refer to our detailed [tutorial on backing up and restoring etcd chart deployments on Kubernetes](https://docs.bitnami.com/general/infrastructure/etcd/administration/backup-restore/), which covers both these approaches, for more information.

--- a/charts/spark/_submit_application.md.erb
+++ b/charts/spark/_submit_application.md.erb
@@ -14,6 +14,4 @@ The command below illustrates the process of deploying one of the sample applica
 
     $ ./bin/spark-submit --class org.apache.spark.examples.SparkPi --master spark://MASTER-IP-ADDRESS:MASTER-PORT  --deploy-mode cluster  ./examples/jars/spark-examples_2.11-2.4.3.jar 1000
 
-For a complete walkthrough of the process using a custom application, refer to the [detailed Apache Spark tutorial](https://docs.bitnami.com/tutorials/process-data-spark-kubernetes/).
-
 > NOTE: It is currently not possible to submit an application to a standalone cluster if RPC authentication is configured. [Learn more about this issue](https://issues.apache.org/jira/browse/SPARK-25078).


### PR DESCRIPTION
Fixing link for `etcd` and removing section for `spark`.