### PR TITLE
Update kubeapps-related references

### DIFF
--- a/_get_started_kubernetes.md.erb
+++ b/_get_started_kubernetes.md.erb
@@ -301,7 +301,7 @@ To learn more about the topics discussed in this guide, use the links below:
 
 * [Production-ready Kubernetes applications by Bitnami](https://bitnami.com/kubernetes)
 * [Intro to deploying your favourite apps on Kubernetes](https://www.youtube.com/watch?v=bd8mXpFLUig)
-* [Kubeapps](http://kubeapps.dev/)
+* [Kubeapps](https://kubeapps.dev/)
 * [Kubernetes](https://kubernetes.io/)
 * [Helm](https://helm.sh/)
 * [Google Kubernetes Engine](https://cloud.google.com/container-engine/)

--- a/_get_started_kubernetes.md.erb
+++ b/_get_started_kubernetes.md.erb
@@ -140,15 +140,6 @@ Add the Bitnami repository to Helm with the following command:
 
 A Helm chart describes a specific version of an application, also known as a "release". The "release" includes files with Kubernetes-needed resources and files that describe the installation, configuration, usage and license of a chart.
 
-The steps below show how to run the following Bitnami applications using Helm charts:
-
-* [Redis](https://kubeapps.com/charts/bitnami/redis)
-* [MongoDB](https://kubeapps.com/charts/bitnami/mongodb)
-* [Odoo](https://kubeapps.com/charts/bitnami/odoo)
-* [WordPress](https://kubeapps.com/charts/bitnami/wordpress)
-
-These are just some concrete examples of application releases. [Find more Bitnami charts](https://kubeapps.com/charts/search?q=bitnami).
-
 By executing the *helm install* command the application will be deployed on the Kubernetes cluster. You can install more than one chart across the cluster or clusters.
 
 > IMPORTANT: If you don't specify a release name, one will be automatically assigned.
@@ -310,7 +301,7 @@ To learn more about the topics discussed in this guide, use the links below:
 
 * [Production-ready Kubernetes applications by Bitnami](https://bitnami.com/kubernetes)
 * [Intro to deploying your favourite apps on Kubernetes](https://www.youtube.com/watch?v=bd8mXpFLUig)
-* [Kubeapps](http://kubeapps.com/)
+* [Kubeapps](http://kubeapps.dev/)
 * [Kubernetes](https://kubernetes.io/)
 * [Helm](https://helm.sh/)
 * [Google Kubernetes Engine](https://cloud.google.com/container-engine/)

--- a/charts/kubeapps/_configure_database.md.erb
+++ b/charts/kubeapps/_configure_database.md.erb
@@ -8,6 +8,6 @@ category: configuration
 weight: 30
 =end %>
 
-Kubeapps supports two database types: MongoDB or PostgreSQL. By default MongoDB is installed. If you want to enable PostgreSQL instead set the following values when installing the application: mongodb.enabled=false and postresql.enabled=true.
+Kubeapps only supports PostgreSQL databases.
 
 > NOTE: Changing the database type when upgrading is not supported.

--- a/charts/kubeapps/_configure_initial_repositories.md.erb
+++ b/charts/kubeapps/_configure_initial_repositories.md.erb
@@ -8,4 +8,4 @@ category: configuration
 weight: 20
 =end %>
 
-By default, Kubeapps will track the community [Helm charts](https://github.com/helm/charts) and the [Kubernetes Service Catalog](https://github.com/kubernetes-sigs/service-catalog) charts. To change these defaults, override with your desired parameters the apprepository.initialRepos object present in the [*values.yaml*](https://github.com/bitnami/charts/blob/main/bitnami/kubeapps/values.yaml) file.
+By default, Kubeapps will track the Helm charts of the [Bitnami Application Catalog](https://github.com/bitnami/charts). To change these defaults, override with your desired parameters the apprepository.initialRepos object present in the [*values.yaml*](https://github.com/bitnami/charts/blob/main/bitnami/kubeapps/values.yaml) file.

--- a/charts/kubeapps/_expose_service.md.erb
+++ b/charts/kubeapps/_expose_service.md.erb
@@ -8,8 +8,6 @@ category: configuration
 weight: 40
 =end %>
 
-> NOTE: The Kubeapps frontend sets up a proxy to the Kubernetes API service, so when when exposing the Kubeapps service to a network external to the Kubernetes cluster (perhaps on an internal or public network), the Kubernetes API will also be exposed on that network. See the [issues section](https://github.com/kubeapps/kubeapps/issues/1111) for more details.
-
 ### LoadBalancer Service
 
 The simplest way to expose the Kubeapps Dashboard is to assign a LoadBalancer type to the Kubeapps frontend Service. For example, you can use the following parameter: frontend.service.type=LoadBalancer
@@ -22,7 +20,7 @@ $ kubectl get services --namespace kubeapps --watch
 
 ### Ingress
 
-This chart provides support for ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress](https://hub.kubeapps.com/charts/stable/nginx-ingress) or [traefik](https://hub.kubeapps.com/charts/stable/traefik) you can utilize the ingress controller to expose Kubeapps.
+This chart provides support for Ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress-controller](https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller) or [contour](https://github.com/bitnami/charts/tree/main/bitnami/contour) you can utilize the ingress controller to serve your application.
 
 To enable ingress integration, please set ingress.enabled to *true*.
 

--- a/common/_configure_ingress.md.erb
+++ b/common/_configure_ingress.md.erb
@@ -9,7 +9,7 @@ weight: 40
 highlight: 40
 =end %>
 
-This chart supports Ingress resources. If an Ingress controller, such as [nginx-ingress](https://hub.kubeapps.com/charts/stable/nginx-ingress) or [traefik](https://hub.kubeapps.com/charts/stable/traefik), is installed in the cluster, that Ingress controller can be used to serve the application.
+This chart provides support for Ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress-controller](https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller) or [contour](https://github.com/bitnami/charts/tree/main/bitnami/contour) you can utilize the ingress controller to serve your application.
 
 To enable Ingress integration, set the *\*.ingress.enabled* parameter to *true*.
 


### PR DESCRIPTION
This PR simply updates some Kubeapps-related outdated references. We should double-check if the Kubeapps-related doc pages are still relevant at all. 